### PR TITLE
Reduce logger spam for empty texture slots

### DIFF
--- a/xbuf_export.py
+++ b/xbuf_export.py
@@ -642,6 +642,8 @@ def export_material(src_mat, dst_mat, cfg):
                 export_tex(textureSlot, dst_mat.opacity_map, cfg)
             elif textureSlot.use_map_normal:
                 export_tex(textureSlot, dst_mat.normal_map, cfg)
+        elif textureSlot is None:
+            continue  # Empty Texture Slot
         else:
             print("WARNING: unsupported texture %r" % (textureSlot))
 


### PR DESCRIPTION
Blender has a fixed amount of texture slots and the unused one's are basically `None`. This lead to xbuf spamming "Unsupported texture" and thus worrying the user, just because it didn't notice there was no texture.

So this is only a little cosmetic fix.
