### PR TITLE
Fixes #13 Export Custom Properties for Meshes

### DIFF
--- a/xbuf_export.py
+++ b/xbuf_export.py
@@ -395,6 +395,7 @@ def export_all_geometries(scene, data, cfg):
             if len(obj.data.polygons) != 0 and cfg.need_update(obj.data):
                 meshes = export_meshes(obj, data.meshes, scene, cfg)
                 for material_index, mesh in meshes.items():
+                    export_customproperties(obj.data, mesh, data, cfg)
                     # several object can share the same mesh
                     for obj2 in scene.objects:
                         if obj2.data == obj.data:


### PR DESCRIPTION
So I've only tested this based on the latest release (v0.91?) but since then `export_object_customproperties` was renamed to `export_customproperties` and it has been added to textures and such, so I think it should work just fine.

If this was a wrong approach just comment though and I'll fix the PR